### PR TITLE
Fixup system logic

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -16,14 +16,15 @@ public final class Constants {
   public static final class ShooterConstants {
     public static final int kShooterMotorLeaderPort = 1;
     public static final int kShooterMotorFollowerPort = 2;
-    public static final double kShooterFenderRPM = 1950;
-    public static final double kShooterRPMThreshold = 50;
+    public static final double kShooterFenderRPM = 1700;
+    public static final double kShooterRPMThreshold = 75;
     public static final double kPower = 0.6;
-    // TODO: Rerun SysId
-    public static final double kS = 0.23638;
-    public static final double kV = 0.1292;
-    public static final double kA = 0.0094019;
+    public static final double kS = 0.39592;
+    public static final double kV = 0.15034;
+    public static final double kA = 0.0099325;
     public static final double kP = 0.0001;
+
+    public static final double kRampUpTimeoutSeconds = 2.5;
   }
 
   public static final class ControllerConstants {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -118,7 +118,7 @@ public class RobotContainer {
             });
 
     new JoystickButton(m_operatorController, Button.kB.value)
-        .whenPressed(
+        .whileHeld(
             () -> {
               m_indexer.setState(IndexerState.kFeeding);
             },
@@ -130,7 +130,7 @@ public class RobotContainer {
             m_indexer);
 
     new JoystickButton(m_operatorController, Button.kA.value)
-        .whenPressed(
+        .whileHeld(
             () -> {
               m_indexer.setState(IndexerState.kReverse);
             },

--- a/src/main/java/frc/robot/commands/SetFlywheelSpeed.java
+++ b/src/main/java/frc/robot/commands/SetFlywheelSpeed.java
@@ -42,6 +42,6 @@ public class SetFlywheelSpeed extends CommandBase {
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return Math.abs(m_shooter.getRPM() - m_targetRPM) < ShooterConstants.kShooterRPMThreshold;
+    return Math.abs(m_shooter.getRPM() - m_targetRPM) <= ShooterConstants.kShooterRPMThreshold;
   }
 }

--- a/src/main/java/frc/robot/commands/ShootCommand.java
+++ b/src/main/java/frc/robot/commands/ShootCommand.java
@@ -6,6 +6,7 @@ package frc.robot.commands;
 
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import frc.robot.Constants.ShooterConstants;
 import frc.robot.subsystems.Indexer;
 import frc.robot.subsystems.Indexer.IndexerState;
 import frc.robot.subsystems.Shooter;
@@ -19,9 +20,11 @@ public class ShootCommand extends SequentialCommandGroup {
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
     addCommands(
-        new SetFlywheelSpeed(RPM, shooter, indexer),
+        new SetFlywheelSpeed(RPM, shooter, indexer)
+            .withTimeout(ShooterConstants.kRampUpTimeoutSeconds),
         new RunCommand(
             () -> {
+              shooter.setRPM(RPM);
               indexer.setState(IndexerState.kFeeding);
             },
             indexer));
@@ -31,7 +34,8 @@ public class ShootCommand extends SequentialCommandGroup {
     // Add your commands in the addCommands() call, e.g.
     // addCommands(new FooCommand(), new BarCommand());
     addCommands(
-        new SetFlywheelSpeed(RPM, shooter, indexer),
+        new SetFlywheelSpeed(RPM, shooter, indexer)
+            .withTimeout(ShooterConstants.kRampUpTimeoutSeconds),
         new RunCommand(
                 () -> {
                   indexer.setState(IndexerState.kFeeding);

--- a/src/main/java/frc/robot/subsystems/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/Indexer.java
@@ -33,7 +33,10 @@ public class Indexer extends SubsystemBase {
     kStopped
   }
   /** Creates a new Indexer. */
-  public Indexer() {}
+  public Indexer() {
+    m_ballElevatorMotor.configFactoryDefault();
+    m_indexerMotor.configFactoryDefault();
+  }
 
   /**
    * Get the pigeon hooked to the indexer Talon SRX

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -5,6 +5,7 @@
 package frc.robot.subsystems;
 
 import static edu.wpi.first.wpilibj.DoubleSolenoid.Value.kForward;
+import static edu.wpi.first.wpilibj.DoubleSolenoid.Value.kOff;
 import static edu.wpi.first.wpilibj.DoubleSolenoid.Value.kReverse;
 
 import com.ctre.phoenix.motorcontrol.can.WPI_VictorSPX;
@@ -25,7 +26,8 @@ public class Intake extends SubsystemBase {
 
   /** Creates a new Intake. */
   public Intake() {
-    m_intakeSolenoid.set(kReverse);
+    m_intakeMotor.configFactoryDefault();
+    m_intakeSolenoid.set(kOff);
   }
 
   public void extendIntake() {

--- a/src/main/java/frc/robot/subsystems/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/Shooter.java
@@ -5,10 +5,9 @@
 package frc.robot.subsystems;
 
 import com.revrobotics.CANSparkMax;
-import com.revrobotics.CANSparkMax.ControlType;
+import com.revrobotics.CANSparkMax.IdleMode;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
 import com.revrobotics.SparkMaxPIDController;
-import com.revrobotics.SparkMaxPIDController.ArbFFUnits;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
@@ -30,19 +29,23 @@ public class Shooter extends SubsystemBase {
 
   /** Creates a new Shooter */
   public Shooter() {
+    m_shooterMotorLeader.restoreFactoryDefaults();
+    m_shooterMotorFollower.restoreFactoryDefaults();
     m_shooterMotorLeader.setInverted(true);
     m_shooterMotorFollower.follow(m_shooterMotorLeader, true);
     m_shooterController.setP(ShooterConstants.kP);
+
+    m_shooterMotorLeader.setIdleMode(IdleMode.kCoast);
+    m_shooterMotorFollower.setIdleMode(IdleMode.kCoast);
   }
 
   public void setRPM(double RPM) {
     double feedForward = m_flywheelFeedforward.calculate(RPM / 60);
-    m_shooterController.setReference(
-        RPM, ControlType.kVelocity, 0, feedForward, ArbFFUnits.kVoltage);
+    m_shooterMotorLeader.setVoltage(feedForward);
   }
 
   public double getRPM() {
-    return m_shooterMotorLeader.getEncoder().getVelocity() * 2;
+    return m_shooterMotorLeader.getEncoder().getVelocity();
   }
 
   @Override


### PR DESCRIPTION
Updates button bindings, constants.

Adds a timeout to flywheel running command.

Reverts to controlling / measuring output shaft of shooter rather than flywheel due to increased noise from gearing down.

Factory resets most motor controllers to hopefully reduce weird hardware bugs experienced while testing.